### PR TITLE
splash 처리 간소화

### DIFF
--- a/src/App/App.tsx
+++ b/src/App/App.tsx
@@ -1,8 +1,24 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
+import { Text } from "react-native";
 import { NavigationContainer } from "@react-navigation/native";
 import { AppStackNavigator } from "@Navigator/App.stack.navigator";
 
 export default function App() {
+  const [loadingEnds, setLoadingEnds] = useState<boolean>(false);
+
+  useEffect(() => {
+    const loadInfo = () =>
+      setTimeout(() => {
+        setLoadingEnds(true);
+      }, 2000);
+    loadInfo();
+    return;
+  }, []);
+
+  if (!loadingEnds) {
+    return <Text>로딩 중입니다.</Text>;
+  }
+
   return (
     <NavigationContainer>
       <AppStackNavigator />

--- a/src/Navigator/Main.bottomTab.navigator.tsx
+++ b/src/Navigator/Main.bottomTab.navigator.tsx
@@ -1,41 +1,47 @@
 import React from "react";
 import { createBottomTabNavigator } from "@react-navigation/bottom-tabs";
 import styled from "styled-components/native";
-import { 
-  ClientStackNavigator, ClientStackProps, 
-  ResearchStackNavigator, ResearchStackProps, 
-  HomeStackNavigator, HomeStackProps, 
-  CommunityStackNavigator, CommunityStackProps, 
-  ProfileStackNavigator, ProfileStackProps, 
+import {
+  ClientStackNavigator,
+  ClientStackProps,
+  ResearchStackNavigator,
+  ResearchStackProps,
+  HomeStackNavigator,
+  HomeStackProps,
+  CommunityStackNavigator,
+  CommunityStackProps,
+  ProfileStackNavigator,
+  ProfileStackProps,
 } from "@Navigator/index";
-import { getFocusedRouteNameFromRoute, Route, RouteProp } from "@react-navigation/native";
+import {
+  getFocusedRouteNameFromRoute,
+  Route,
+  RouteProp,
+} from "@react-navigation/native";
 import { BackHandler } from "react-native";
 
 const MainBottomTab = createBottomTabNavigator<MainBottomTabProps>();
 
 /**
- * @param route 
+ * @param route
  * @returns bottom tab의 display type
- * 
+ *
  * determineBottomTabVisibility는 route를 통해 bottomTab을 보여줄 지 말지 결정합니다.
  * 이 함수를 Navigator에 바로 사용하면, 화면을 이동할 때마다 모든 자식 스택의 route를 추적합니다.
  * 따라서 각 Screen에 함수를 따로따로 적용시켜주는 것이 안전합니다.
  */
 function determineBottomTabVisibility(route: any) {
-
-  let screenName: undefined|string = undefined
+  let screenName: undefined | string = undefined;
   screenName = getFocusedRouteNameFromRoute(route);
 
   if (screenName !== undefined) {
     console.log(screenName);
-    if (!(["ResearchDetailScreen"].includes(screenName))) {
-      return "flex"
-    } 
-    return "none"
+    if (!["ResearchDetailScreen"].includes(screenName)) {
+      return "flex";
+    }
+    return "none";
   }
 }
-
-
 
 /**
  * 앱 메인 하단바 네비게이터입니다. 사실상 앱 그 자체입니다.
@@ -43,28 +49,27 @@ function determineBottomTabVisibility(route: any) {
  * @author 현웅
  */
 export function MainBottomTabNavigator() {
-  BackHandler.addEventListener("hardwareBackPress", function() {
+  BackHandler.addEventListener("hardwareBackPress", function () {
     /**
      * @Unsolved
      * @Task backPress를 하였을 때 Modal을 띄우거나, 한 번더 누르면 종료합니다 등의 처리
      */
-    console.log("MainBottomTab에서는 backPress가 유효하지 않습니다")
-    return true
-  })
+    console.log("MainBottomTab에서는 backPress가 유효하지 않습니다");
+    return true;
+  });
   return (
     <MainBottomTab.Navigator
       initialRouteName="HomeStack"
-      screenOptions={({ route }) => ({ 
+      screenOptions={({ route }) => ({
         headerShown: false,
         tabBarShowLabel: false,
-      }
-    )}>
+      })}>
       <MainBottomTab.Screen
         name={"ClientStack"}
         component={ClientStackNavigator}
         options={({ route }) => ({
           tabBarStyle: {
-            display: determineBottomTabVisibility(route)
+            display: determineBottomTabVisibility(route),
           },
           tabBarIcon: ({ focused }) => (
             <BottomTabIconView>
@@ -94,7 +99,7 @@ export function MainBottomTabNavigator() {
         component={ResearchStackNavigator}
         options={({ route }) => ({
           tabBarStyle: {
-            display: determineBottomTabVisibility(route)
+            display: determineBottomTabVisibility(route),
           },
           tabBarIcon: ({ focused }) => (
             <BottomTabIconView>
@@ -110,7 +115,7 @@ export function MainBottomTabNavigator() {
                   {bottomTabResource.Research.label}
                 </BottomTabIconFocusedText>
               ) : (
-                <BottomTabIconUnfocusedText>  
+                <BottomTabIconUnfocusedText>
                   {bottomTabResource.Research.label}
                 </BottomTabIconUnfocusedText>
               )}
@@ -123,7 +128,7 @@ export function MainBottomTabNavigator() {
         component={HomeStackNavigator}
         options={({ route }) => ({
           tabBarStyle: {
-            display: determineBottomTabVisibility(route)
+            display: determineBottomTabVisibility(route),
           },
           tabBarIcon: ({ focused }) => (
             <BottomTabMainIconView>
@@ -143,7 +148,7 @@ export function MainBottomTabNavigator() {
         component={CommunityStackNavigator}
         options={({ route }) => ({
           tabBarStyle: {
-            display: determineBottomTabVisibility(route)
+            display: determineBottomTabVisibility(route),
           },
           tabBarIcon: ({ focused }) => (
             <BottomTabIconView>
@@ -172,7 +177,7 @@ export function MainBottomTabNavigator() {
         component={ProfileStackNavigator}
         options={({ route }) => ({
           tabBarStyle: {
-            display: determineBottomTabVisibility(route)
+            display: determineBottomTabVisibility(route),
           },
           tabBarIcon: ({ focused }) => (
             <BottomTabIconView>
@@ -245,8 +250,6 @@ const bottomTabResource = {
     },
   },
 };
-
-
 
 const BottomTabIconView = styled.View`
   align-items: center;


### PR DESCRIPTION
Splash 스크린을 스택에 쌓는 것 자체가 조금 불안정하기도 하고 (버그가 나서 splash 스크린으로 돌아간다든가)
실제로도 지금 뒤로 가기 버튼을 눌러서 앱을 종료하는 게 안 되기 때문에, 수정해야할 듯.
(App.tsx 변경사항만 보면 됨. Main.bottomTab.navigator.tsx는 prettier 때문에 자동 줄바꿈 된 것들 뿐임.)